### PR TITLE
resin-init-board: Add script to ensure correct future EFI boot

### DIFF
--- a/layers/meta-resin-genericx86/recipes-support/resin-init/resin-init-board.bbappend
+++ b/layers/meta-resin-genericx86/recipes-support/resin-init/resin-init-board.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_append_artik10 := "${THISDIR}/${PN}"

--- a/layers/meta-resin-genericx86/recipes-support/resin-init/resin-init-board/resin-init-board
+++ b/layers/meta-resin-genericx86/recipes-support/resin-init/resin-init-board/resin-init-board
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+# make sure the bootstrap code (boot.img) is removed in case we are using EFI boot
+if [ -d /sys/firmware/efi ] ; then
+    device="/dev/"$(findmnt --noheadings --canonicalize --output SOURCE /mnt/boot/ | xargs lsblk -no pkname)
+    dd if=/dev/zero of=$device bs=446 count=1
+fi
+
+exit 0


### PR DESCRIPTION
It's been observed on EFI machines that at the first boot after
provisioning there is some bootstrap code in the first sector of
the boot media (even though during provisioning we make sure we
remove this bootstrap code). In such a case (only on some machines),
the next time we reboot the machine, it will not recognize the media
as a valid EFI boot media and the boot will fail.

Changelog-entry: Add script to ensure correct future EFI boot
Signed-off-by: Florin Sarbu <florin@balena.io>